### PR TITLE
#19 Github action for gradle plugin release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Gradle Plugin Publish
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    name: Publish plugin to gradle plugins portal
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 12
+        uses: actions/setup-java@v1
+        with:
+          java-version: 12
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - run: cat ./gradle.properties
+      - name: Publish plugins with gradle
+        env:
+          GRADLE_PUBLISH_KEY: ${{ secrets.PUBLISH_KEY }}
+          GRADLE_PUBLISH_SECRET: ${{ secrets.PUBLISH_SECRET }}
+        run: ./gradlew publishPlugins -Pgradle.publish.key=$GRADLE_PUBLISH_KEY -Pgradle.publish.secret=$GRADLE_PUBLISH_SECRET


### PR DESCRIPTION
Resolves #20 

At least, this provide a way to publish plugin to gradle portal.

Let's think about the previous steps in manual in this time.

Hope this release is fine with this guide.
https://github.com/line/gradle-multi-project-support/wiki/Release-process